### PR TITLE
Add a phasedcache template tag

### DIFF
--- a/docs/templatetag.rst
+++ b/docs/templatetag.rst
@@ -8,3 +8,5 @@ Template tag
 
 .. autofunction:: phased.templatetags.phased_tags.phased
 .. autofunction:: phased.templatetags.phased_tags.parse
+
+.. autofunction:: phased.templatetags.phased_tags.phasedcache

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -32,6 +32,11 @@ Configuration
 To make django-phased tags available to your templates, add ``'phased'`` to
 your ``INSTALLED_APPS``.
 
+You can either use ``phased`` via the ``PhasedRenderMiddleware`` middleware or via the ``phasedcache`` template tag.
+
+Middleware
+----------
+
 Install :class:`phased.middleware.PhasedRenderMiddleware` to enable
 second-phase rendering of templates.
 
@@ -51,3 +56,14 @@ A common setup for middleware classes would be this:
     )
 
 See :doc:`settings` for additional settings.
+
+
+Template Tag
+------------
+
+In order to use the ``phasedcache`` template tag you need to add ``'django.core.context_processors.request'`` to the ``TEMPLATE_CONTEXT_PROCESSORS`` settings variable and use ``RequestContext``
+when you render your templates.
+
+The ``phasedcache`` template tag works exactly like the Django's ``cache`` template tag except that it will do a second render pass.
+
+See :class:`phased.templatetags.phased_tags.phasedcache` for details.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -32,7 +32,8 @@ Configuration
 To make django-phased tags available to your templates, add ``'phased'`` to
 your ``INSTALLED_APPS``.
 
-You can either use ``phased`` via the ``PhasedRenderMiddleware`` middleware or via the ``phasedcache`` template tag.
+You can either use ``phased`` via the ``PhasedRenderMiddleware``
+middleware or via the ``phasedcache`` template tag.
 
 Middleware
 ----------
@@ -61,9 +62,11 @@ See :doc:`settings` for additional settings.
 Template Tag
 ------------
 
-In order to use the ``phasedcache`` template tag you need to add ``'django.core.context_processors.request'`` to the ``TEMPLATE_CONTEXT_PROCESSORS`` settings variable and use ``RequestContext``
-when you render your templates.
+In order to use the ``phasedcache`` template tag you need to add
+``'django.core.context_processors.request'`` to the ``TEMPLATE_CONTEXT_PROCESSORS``
+settingsvariable and use ``RequestContext`` when you render your templates.
 
-The ``phasedcache`` template tag works exactly like the Django's ``cache`` template tag except that it will do a second render pass.
+The ``phasedcache`` template tag works exactly like the Django's ``cache`` template
+tag except that it will do a second render pass.
 
 See :class:`phased.templatetags.phased_tags.phasedcache` for details.

--- a/phased/templatetags/phased_tags.py
+++ b/phased/templatetags/phased_tags.py
@@ -129,18 +129,21 @@ class PhasedCacheNode(CacheNode):
 
 
 @register.tag('phasedcache')
-def do_cache(parser, token):
+def phasedcache(parser, token):
     """
-    Taken from django.templatetags.cache and changed ending tag.
+    Taken from ``django.templatetags.cache`` and changed ending tag.
 
     This will cache the contents of a template fragment for a given amount
-    of time and do a second pass render on the contents
+    of time and do a second pass render on the contents.
 
     Usage::
 
         {% load phased_tags %}
         {% phasedcache [expire_time] [fragment_name] %}
             .. some expensive processing ..
+            {% phased %}
+                .. some request specific stuff ..
+            {% endphased %}
         {% endphasedcache %}
 
     This tag also supports varying by a list of arguments::
@@ -148,9 +151,17 @@ def do_cache(parser, token):
         {% load phased_tags %}
         {% phasedcache [expire_time] [fragment_name] [var1] [var2] .. %}
             .. some expensive processing ..
+            {% phased %}
+                .. some request specific stuff ..
+            {% endphased %}
         {% endphasedcache %}
 
     Each unique set of arguments will result in a unique cache entry.
+    The tag will take care that the phased tags are properly rendered.
+
+    It requires usage of ``RequestContext`` and
+    ``django.core.context_processors.request`` to be in the
+    ``TEMPLATE_CONTEXT_PROCESSORS`` setting.
     """
     nodelist = parser.parse(('endphasedcache',))
     parser.delete_first_token()

--- a/phased/templatetags/phased_tags.py
+++ b/phased/templatetags/phased_tags.py
@@ -128,7 +128,7 @@ class PhasedCacheNode(CacheNode):
         return second_pass_render(context['request'], content)
 
 
-@register.tag('phasedcache')
+@register.tag
 def phasedcache(parser, token):
     """
     Taken from ``django.templatetags.cache`` and changed ending tag.

--- a/phased/templatetags/phased_tags.py
+++ b/phased/templatetags/phased_tags.py
@@ -3,8 +3,9 @@ from django.template import (Library, Node, Variable,
     TOKEN_BLOCK, TOKEN_COMMENT, TOKEN_TEXT, TOKEN_VAR,
     TemplateSyntaxError, VariableDoesNotExist, Context)
 from django.utils.encoding import smart_str
+from django.templatetags.cache import CacheNode
 
-from phased.utils import pickle_context, flatten_context, backup_csrf_token
+from phased.utils import pickle_context, flatten_context, backup_csrf_token, second_pass_render
 
 register = Library()
 
@@ -111,3 +112,49 @@ def phased(parser, token):
         if len(tokens) == 2:
             raise TemplateSyntaxError(u"'%r' tag requires at least one context variable name." % tokens[0])
     return PhasedNode(literal, tokens[2:])
+
+
+class PhasedCacheNode(CacheNode):
+    def render(self, context):
+        """
+        Template tag that acts like Django's cached tag
+        except that it does a second pass rendering.
+
+        Requires `RequestContext` and
+        `django.core.context_processors.request` to be in
+        TEMPLATE_CONTEXT_PROCESSORS
+        """
+        content = super(PhasedCacheNode, self).render(context)
+        return second_pass_render(context['request'], content)
+
+
+@register.tag('phasedcache')
+def do_cache(parser, token):
+    """
+    Taken from django.templatetags.cache and changed ending tag.
+
+    This will cache the contents of a template fragment for a given amount
+    of time and do a second pass render on the contents
+
+    Usage::
+
+        {% load phased_tags %}
+        {% phasedcache [expire_time] [fragment_name] %}
+            .. some expensive processing ..
+        {% endphasedcache %}
+
+    This tag also supports varying by a list of arguments::
+
+        {% load phased_tags %}
+        {% phasedcache [expire_time] [fragment_name] [var1] [var2] .. %}
+            .. some expensive processing ..
+        {% endphasedcache %}
+
+    Each unique set of arguments will result in a unique cache entry.
+    """
+    nodelist = parser.parse(('endphasedcache',))
+    parser.delete_first_token()
+    tokens = token.contents.split()
+    if len(tokens) < 3:
+        raise TemplateSyntaxError(u"'%r' tag requires at least 2 arguments." % tokens[0])
+    return PhasedCacheNode(nodelist, tokens[1], tokens[2], tokens[3:])

--- a/phased/test_cases.py
+++ b/phased/test_cases.py
@@ -231,9 +231,7 @@ class PatchedVaryUpdateCacheMiddlewareTestCase(PhasedTestCase):
 
     def setUp(self):
         super(PatchedVaryUpdateCacheMiddlewareTestCase, self).setUp()
-        # clear cache
-        for key in cache._cache.keys():
-            cache.delete(key)
+        cache.clear()
 
     def test_no_vary(self):
         """

--- a/phased/test_cases.py
+++ b/phased/test_cases.py
@@ -8,7 +8,8 @@ from django.core.cache import cache
 from django.http import HttpResponse
 from django.middleware.cache import FetchFromCacheMiddleware, UpdateCacheMiddleware
 from django.utils.cache import patch_vary_headers
-from django.template import compile_string, Context, TemplateSyntaxError
+from django.template import (compile_string, Context, TemplateSyntaxError,
+        RequestContext)
 from django.test.client import RequestFactory
 from django.test import TestCase
 
@@ -340,3 +341,37 @@ class PatchedVaryUpdateCacheMiddlewareTestCase(PhasedTestCase):
         self.assertEqual(response['Vary'], 'Nomnomnom')
         drop_vary_headers(response, ['Nomnomnom'])
         self.assertFalse(response.has_header('Vary'))
+
+
+class PhasedCacheTemplateTagTest(PhasedTestCase):
+    test_template = (
+        "{% load phased_tags %}"
+        "OtherPart"
+        "{% phasedcache 10000 phased_test %}"
+        "{{ test_var }}"
+        "{% phased %}"
+        "{{ request.path }}"
+        "{% endphased %}"
+        "{% endphasedcache %}"
+        "TEST"
+    )
+
+    def setUp(self):
+        super(PhasedCacheTemplateTagTest, self).setUp()
+        cache.clear()
+
+    def test_phasedcache(self):
+        self.assertEqual(len(cache._cache.keys()), 0)
+        request = self.factory.get('/')
+        context = RequestContext(request, {'test_var': 'Testing'})
+        rendering = compile_string(self.test_template, None).render(context)
+        self.assertEqual(rendering, 'OtherPartTesting/TEST')
+        self.assertEqual(len(cache._cache.keys()), 1)
+        cached_value = cache.get('template.cache.phased_test.d41d8cd98f00b204e9800998ecf8427e')
+        self.assertIsNotNone(cached_value)
+        self.assertTrue(cached_value.startswith('Testing'))
+        request = self.factory.get('/path/')
+        # Do not make test_var available, should be in cache
+        context = RequestContext(request)
+        rendering = compile_string(self.test_template, None).render(context)
+        self.assertEqual(rendering, 'OtherPartTesting/path/TEST')

--- a/phased/test_settings.py
+++ b/phased/test_settings.py
@@ -25,3 +25,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
 )
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    'django.core.context_processors.request',
+)


### PR DESCRIPTION
If you don't want to use the phased middleware, this template tag acts like Django's cache template tag, but does a second render pass on the result.

Requires the `django.core.context_processors.request` template context processor and a `RequestContext` instance when rendering.

/cc @jezdez
