### PR TITLE
Support non existent variables

### DIFF
--- a/phased/templatetags/phased_tags.py
+++ b/phased/templatetags/phased_tags.py
@@ -59,8 +59,7 @@ class PhasedNode(Node):
             try:
                 storage[var_name] = Variable(var_name).resolve(context)
             except VariableDoesNotExist:
-                raise TemplateSyntaxError(
-                    '"phased" tag got an unknown variable: %r' % var_name)
+                storage[var_name] = None
 
         storage = backup_csrf_token(context, storage)
 

--- a/phased/test_cases.py
+++ b/phased/test_cases.py
@@ -101,7 +101,7 @@ class NestedTwoPhaseTestCase(TwoPhaseTestCase):
         self.assertEqual(second_render, 'firstsecondTEST')
 
 
-class PhaseEmptyVariableTestCase(TwoPhaseTestCase):
+class PhaseEmptyVariableTestCase(PhasedTestCase):
     test_template = (
         "{% load phased_tags %}"
         "{% phased with bob %}"
@@ -169,8 +169,6 @@ class PickyStashedTestCase(StashedTestCase):
     )
 
     def test_phased(self):
-        context = Context({'test_var': 'TEST'})
-        self.assertRaises(TemplateSyntaxError, compile_string(self.test_template, None).render, context)
         context = Context({
             'test_var': 'TEST',
             'test_condition': True,

--- a/phased/test_cases.py
+++ b/phased/test_cases.py
@@ -101,6 +101,22 @@ class NestedTwoPhaseTestCase(TwoPhaseTestCase):
         self.assertEqual(second_render, 'firstsecondTEST')
 
 
+class PhaseEmptyVariableTestCase(TwoPhaseTestCase):
+    test_template = (
+        "{% load phased_tags %}"
+        "{% phased with bob %}"
+        "{% if not bob %}test{% endif %}"
+        "{% endphased %}"
+    )
+
+    def test_second_pass(self):
+        request = self.factory.get('/')
+        # Don't pass in a 'bob' variable
+        first_render = compile_string(self.test_template, None).render(Context({}))
+        second_render = second_pass_render(request, first_render)
+        self.assertEqual(second_render, 'test')
+
+
 class StashedTestCase(TwoPhaseTestCase):
     test_template = (
         "{% load phased_tags %}"


### PR DESCRIPTION
More or less all other Django template tags allow you to pass in a variable name for a variable not present in the template context. In all these cases, the variable is simply ignored.

This PR adds support for this convention.  We needed this to avoid lots of conditional checks (do x, y and z variables exist? If so, run phased with this, or this, or this) wrapped around our `{% phased .. %}` template tags.

Based on the test cases, this behavior appears intentional, but I believe it may be counter-intuitive.
