### PR TITLE
Check to see if response has Content-Length before setting it.

### DIFF
--- a/phased/middleware.py
+++ b/phased/middleware.py
@@ -19,7 +19,9 @@ class PhasedRenderMiddleware(object):
         if not response['content-type'].startswith("text/html"):
             return response
         response.content = second_pass_render(request, response.content)
-        response['Content-Length'] = str(len(response.content))
+        # Fix the Content-Length if it's been set.
+        if 'Content-Length' in response:
+            response['Content-Length'] = str(len(response.content))
         return response
 
 


### PR DESCRIPTION
Because of https://github.com/codysoyland/django-phased/issues/12, I had to move `PhasedRenderMiddleware` to the bottom(ish) of my `MIDDLEWARE_CLASSES`. This fixed the issue with the `MessageMiddleware`, but caused new issues with other middleware I had that altered the length of the response.

Ideally, these other middleware classes would check to see if `Content-Length` was set, and if so, re-adjust the content length header. Unfortunately, this doesn't seem to be the case, and it seems smart for us to check to see if the header's set before adding it in here, anyway.
